### PR TITLE
Also transform namespace URIs, etc.

### DIFF
--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -40,7 +40,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:copy>
 </xsl:template>
 
-	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139)-->
+	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->
 <xsl:template match="aixm:RulesProcedures//aixm:title[text()='HOLDING_APPROACH_DEPARTURE_PROCEDURES']">
 	<xsl:copy>
 		<xsl:text>HOLDING_ APPROACH_DEPARTURE_PROCEDURES</xsl:text>
@@ -65,14 +65,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:copy>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143)-->
+	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
 <xsl:template match="aixm:TerminalSegmentPoint//aixm:role[text()='LTP']">
 	<xsl:copy>
 		<xsl:text>OTHER:LTP</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-146 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-146)-->
+	<!--script implementing change proposal AIXM-146 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-146 )-->
 <xsl:template match="aixm:StandardLevelColumnTimeSlice[aixm:unitOfMeasurement]">
 	<xsl:choose>
 		<xsl:when test="aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
@@ -231,28 +231,28 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:choose>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147)-->
+	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
 <xsl:template match="aixm:Navaid//aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
 	<xsl:copy>
 		<xsl:value-of select="concat('OTHER:',.)"/>
 	</xsl:copy>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150)-->
+	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
 <xsl:template match="aixm:AircraftCharacteristic//aixm:engine[text()='ELECTRIC']">
 	<xsl:copy>
 		<xsl:value-of select="concat('OTHER:',.)"/>
 	</xsl:copy>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158)-->
+	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
 <xsl:template match="aixm:StandardLevelTable//aixm:name[text()='VFR_RVSM']">
 	<xsl:copy>
 		<xsl:text>VFR_RVMS</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-	<!--script implementing change proposal AIXM-164 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-164)-->
+	<!--script implementing change proposal AIXM-164 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-164 )-->
 	<!--fn:matches was used to identify the required pattern for Note.propertyName-->
 <xsl:template match="aixm:Note[aixm:propertyName]">
 	<xsl:choose>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -74,42 +74,23 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:element>
 </xsl:template>
 
-<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS']">
+<xsl:template match="
+		src_aixm:AircraftStand        //src_aixm:visualDockingSystem[text()=('AGNIS','AGNIS_STOP')]|
+		src_aixm:VerticalStructurePart/ src_aixm:constructionStatus [text()= 'IN_DEMOLITION'      ]">
 	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>AGNIS </xsl:text>
-	</xsl:element>
-</xsl:template>
-
-<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>AGNIS_STOP </xsl:text>
-	</xsl:element>
-</xsl:template>
-
-<xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>IN_DEMOLITION </xsl:text>
+		<xsl:value-of select="concat(text(),' ')"/>
 	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
-<xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='LTP']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>OTHER:LTP</xsl:text>
-	</xsl:element>
-</xsl:template>
-
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
-<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="concat('OTHER:',.)"/>
-	</xsl:element>
-</xsl:template>
-
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
-<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='ELECTRIC']">
+<xsl:template match="
+		src_aixm:TerminalSegmentPoint  //src_aixm:role             [text()= 'LTP'                ]|
+		src_aixm:Navaid                //src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]|
+		src_aixm:AircraftCharacteristic//src_aixm:engine           [text()= 'ELECTRIC'           ]">
 	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="concat('OTHER:',.)"/>
+		<xsl:value-of select="concat('OTHER:',text())"/>
 	</xsl:element>
 </xsl:template>
 

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -34,6 +34,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:src_aixm="http://www.aixm.aero/schema/5.1"
                 xmlns:aixm="http://www.aixm.aero/schema/5.1"
                 xmlns:gml="http://www.opengis.net/gml/3.2">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
@@ -46,53 +47,53 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 </xsl:template>
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->
-<xsl:template match="aixm:RulesProcedures//aixm:title[text()='HOLDING_APPROACH_DEPARTURE_PROCEDURES']">
+<xsl:template match="src_aixm:RulesProcedures//src_aixm:title[text()='HOLDING_APPROACH_DEPARTURE_PROCEDURES']">
 	<xsl:copy>
 		<xsl:text>HOLDING_ APPROACH_DEPARTURE_PROCEDURES</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:AircraftStand//aixm:visualDockingSystem[text()='AGNIS']">
+<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS']">
 	<xsl:copy>
 		<xsl:text>AGNIS </xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:AircraftStand//aixm:visualDockingSystem[text()='AGNIS_STOP']">
+<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP']">
 	<xsl:copy>
 		<xsl:text>AGNIS_STOP </xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:VerticalStructurePart/aixm:constructionStatus[text()='IN_DEMOLITION']">
+<xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION']">
 	<xsl:copy>
 		<xsl:text>IN_DEMOLITION </xsl:text>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
-<xsl:template match="aixm:TerminalSegmentPoint//aixm:role[text()='LTP']">
+<xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='LTP']">
 	<xsl:copy>
 		<xsl:text>OTHER:LTP</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-146 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-146 )-->
-<xsl:template match="aixm:StandardLevelColumnTimeSlice[aixm:unitOfMeasurement]">
+<xsl:template match="src_aixm:StandardLevelColumnTimeSlice[src_aixm:unitOfMeasurement]">
 	<xsl:choose>
-		<xsl:when test="aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
+		<xsl:when test="src_aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="gml:validTime"/>
-				<xsl:apply-templates select="aixm:interpretation"/>
-				<xsl:apply-templates select="aixm:sequenceNumber"/>
-				<xsl:apply-templates select="aixm:correctionNumber"/>
-				<xsl:apply-templates select="aixm:featureLifetime"/>
-				<xsl:apply-templates select="aixm:series"/>
-				<xsl:apply-templates select="aixm:unitOfMeasurement"/>
-				<xsl:apply-templates select="aixm:separation"/>
-				<xsl:apply-templates select="aixm:level"/>
-				<xsl:apply-templates select="aixm:levelTable"/>
+				<xsl:apply-templates select="src_aixm:interpretation"/>
+				<xsl:apply-templates select="src_aixm:sequenceNumber"/>
+				<xsl:apply-templates select="src_aixm:correctionNumber"/>
+				<xsl:apply-templates select="src_aixm:featureLifetime"/>
+				<xsl:apply-templates select="src_aixm:series"/>
+				<xsl:apply-templates select="src_aixm:unitOfMeasurement"/>
+				<xsl:apply-templates select="src_aixm:separation"/>
+				<xsl:apply-templates select="src_aixm:level"/>
+				<xsl:apply-templates select="src_aixm:levelTable"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -102,14 +103,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 							<xsl:element name="aixm:LinguisticNote">
 								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')"/>
 								<xsl:element name="aixm:note">
-									<xsl:value-of select="aixm:unitOfMeasurement/@nilReason"/>
+									<xsl:value-of select="src_aixm:unitOfMeasurement/@nilReason"/>
 								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:apply-templates select="aixm:annotation"/>
-				<xsl:apply-templates select="aixm:extension"/>
+				<xsl:apply-templates select="src_aixm:annotation"/>
+				<xsl:apply-templates select="src_aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -118,21 +119,21 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:choose>
 </xsl:template>
 
-<xsl:template match="aixm:MarkingBuoyTimeSlice[aixm:designator]">
+<xsl:template match="src_aixm:MarkingBuoyTimeSlice[src_aixm:designator]">
 	<xsl:choose>
-		<xsl:when test="aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
+		<xsl:when test="src_aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="gml:validTime"/>
-				<xsl:apply-templates select="aixm:interpretation"/>
-				<xsl:apply-templates select="aixm:sequenceNumber"/>
-				<xsl:apply-templates select="aixm:correctionNumber"/>
-				<xsl:apply-templates select="aixm:featureLifetime"/>
-				<xsl:apply-templates select="aixm:designator"/>
-				<xsl:apply-templates select="aixm:type"/>
-				<xsl:apply-templates select="aixm:colour"/>
-				<xsl:apply-templates select="aixm:theSeaplaneLandingArea"/>
-				<xsl:apply-templates select="aixm:location"/>
+				<xsl:apply-templates select="src_aixm:interpretation"/>
+				<xsl:apply-templates select="src_aixm:sequenceNumber"/>
+				<xsl:apply-templates select="src_aixm:correctionNumber"/>
+				<xsl:apply-templates select="src_aixm:featureLifetime"/>
+				<xsl:apply-templates select="src_aixm:designator"/>
+				<xsl:apply-templates select="src_aixm:type"/>
+				<xsl:apply-templates select="src_aixm:colour"/>
+				<xsl:apply-templates select="src_aixm:theSeaplaneLandingArea"/>
+				<xsl:apply-templates select="src_aixm:location"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -142,14 +143,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 							<xsl:element name="aixm:LinguisticNote">
 								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')"/>
 								<xsl:element name="aixm:note">
-									<xsl:value-of select="aixm:designator/@nilReason"/>
+									<xsl:value-of select="src_aixm:designator/@nilReason"/>
 								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:apply-templates select="aixm:annotation"/>
-				<xsl:apply-templates select="aixm:extension"/>
+				<xsl:apply-templates select="src_aixm:annotation"/>
+				<xsl:apply-templates select="src_aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -158,25 +159,25 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:choose>
 </xsl:template>
 
-<xsl:template match="aixm:FASDataBlock">
+<xsl:template match="src_aixm:FASDataBlock">
 	<xsl:choose>
-		<xsl:when test="aixm:routeIndicator[@nilReason] or aixm:referencePathIdentifier[@nilReason] or aixm:codeICAO[@nilReason]">
+		<xsl:when test="src_aixm:routeIndicator[@nilReason] or src_aixm:referencePathIdentifier[@nilReason] or src_aixm:codeICAO[@nilReason]">
 			<xsl:copy>
 				<xsl:apply-templates select="@gml:id"/>
-				<xsl:apply-templates select="aixm:horizontalAlarmLimit"/>
-				<xsl:apply-templates select="aixm:verticalAlarmLimit"/>
-				<xsl:apply-templates select="aixm:thresholdCourseWidth"/>
-				<xsl:apply-templates select="aixm:lengthOffset"/>
-				<xsl:apply-templates select="aixm:CRCRemainder"/>
-				<xsl:apply-templates select="aixm:operationType"/>
-				<xsl:apply-templates select="aixm:serviceProviderSBAS"/>
-				<xsl:apply-templates select="aixm:approachPerformanceDesignator"/>
-				<xsl:apply-templates select="aixm:routeIndicator"/>
-				<xsl:apply-templates select="aixm:referencePathDataSelector"/>
-				<xsl:apply-templates select="aixm:referencePathIdentifier"/>
-				<xsl:apply-templates select="aixm:codeICAO"/>
-				<xsl:apply-templates select="aixm:annotation"/>
-				<xsl:if test="aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
+				<xsl:apply-templates select="src_aixm:horizontalAlarmLimit"/>
+				<xsl:apply-templates select="src_aixm:verticalAlarmLimit"/>
+				<xsl:apply-templates select="src_aixm:thresholdCourseWidth"/>
+				<xsl:apply-templates select="src_aixm:lengthOffset"/>
+				<xsl:apply-templates select="src_aixm:CRCRemainder"/>
+				<xsl:apply-templates select="src_aixm:operationType"/>
+				<xsl:apply-templates select="src_aixm:serviceProviderSBAS"/>
+				<xsl:apply-templates select="src_aixm:approachPerformanceDesignator"/>
+				<xsl:apply-templates select="src_aixm:routeIndicator"/>
+				<xsl:apply-templates select="src_aixm:referencePathDataSelector"/>
+				<xsl:apply-templates select="src_aixm:referencePathIdentifier"/>
+				<xsl:apply-templates select="src_aixm:codeICAO"/>
+				<xsl:apply-templates select="src_aixm:annotation"/>
+				<xsl:if test="src_aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
 							<xsl:attribute name="gml:id" select="concat('g',generate-id())"/>
@@ -186,14 +187,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 								<xsl:element name="aixm:LinguisticNote">
 									<xsl:attribute name="gml:id" select="concat('g',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
-										<xsl:value-of select="aixm:routeIndicator/@nilReason"/>
+										<xsl:value-of select="src_aixm:routeIndicator/@nilReason"/>
 									</xsl:element>
 								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:if test="aixm:referencePathIdentifier[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
+				<xsl:if test="src_aixm:referencePathIdentifier[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
 							<xsl:attribute name="gml:id" select="concat('a',generate-id())"/>
@@ -203,14 +204,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 								<xsl:element name="aixm:LinguisticNote">
 									<xsl:attribute name="gml:id" select="concat('a',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
-										<xsl:value-of select="aixm:referencePathIdentifier/@nilReason"/>
+										<xsl:value-of select="src_aixm:referencePathIdentifier/@nilReason"/>
 									</xsl:element>
 								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:if test="aixm:codeICAO[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
+				<xsl:if test="src_aixm:codeICAO[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
 							<xsl:attribute name="gml:id" select="concat('d',generate-id())"/>
@@ -220,14 +221,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 								<xsl:element name="aixm:LinguisticNote">
 									<xsl:attribute name="gml:id" select="concat('d',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
-										<xsl:value-of select="aixm:codeICAO/@nilReason"/>
+										<xsl:value-of select="src_aixm:codeICAO/@nilReason"/>
 									</xsl:element>
 								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:apply-templates select="aixm:extension"/>
+				<xsl:apply-templates select="src_aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -237,21 +238,21 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
-<xsl:template match="aixm:Navaid//aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
+<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
 	<xsl:copy>
 		<xsl:value-of select="concat('OTHER:',.)"/>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
-<xsl:template match="aixm:AircraftCharacteristic//aixm:engine[text()='ELECTRIC']">
+<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='ELECTRIC']">
 	<xsl:copy>
 		<xsl:value-of select="concat('OTHER:',.)"/>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
-<xsl:template match="aixm:StandardLevelTable//aixm:name[text()='VFR_RVSM']">
+<xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVSM']">
 	<xsl:copy>
 		<xsl:text>VFR_RVMS</xsl:text>
 	</xsl:copy>
@@ -259,24 +260,24 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 
 	<!--script implementing change proposal AIXM-164 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-164 )-->
 	<!--fn:matches was used to identify the required pattern for Note.propertyName-->
-<xsl:template match="aixm:Note[aixm:propertyName]">
+<xsl:template match="src_aixm:Note[src_aixm:propertyName]">
 	<xsl:choose>
-		<xsl:when test="aixm:propertyName[matches(text(),'^[a-z][A-Za-z]*$')]">
+		<xsl:when test="src_aixm:propertyName[matches(text(),'^[a-z][A-Za-z]*$')]">
 			<xsl:apply-templates select="."/>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:copy>
 				<xsl:apply-templates select="@gml:id"/>
-				<xsl:apply-templates select="aixm:purpose"/>
+				<xsl:apply-templates select="src_aixm:purpose"/>
 				<xsl:element name="aixm:translatedNote">
 					<xsl:element name="aixm:LinguisticNote">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
 						<xsl:element name="aixm:note">
-							<xsl:text>value-of Note.propertyName: </xsl:text><xsl:value-of select="aixm:propertyName"/>
+							<xsl:text>value-of Note.propertyName: </xsl:text><xsl:value-of select="src_aixm:propertyName"/>
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:apply-templates select="aixm:translatedNote"/>
+				<xsl:apply-templates select="src_aixm:translatedNote"/>
 			</xsl:copy>
 		</xsl:otherwise>
 	</xsl:choose>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -34,16 +34,37 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:fn="http://www.w3.org/2005/xpath-functions"
-                xmlns:src_aixm="http://www.aixm.aero/schema/5.1"
+                xmlns:src_aixm="http://www.aixm.aero/schema/5.1.1"
+                xmlns:src_message="http://www.aixm.aero/schema/5.1.1/message"
                 xmlns:aixm="http://www.aixm.aero/schema/5.1"
+                xmlns:message="http://www.aixm.aero/schema/5.1/message"
                 xmlns:gml="http://www.opengis.net/gml/3.2">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->
 <xsl:template match="@*|node()">
-	<xsl:copy>
+	<xsl:copy copy-namespaces="no">
 		<xsl:apply-templates select="@*|node()"/>
 	</xsl:copy>
+</xsl:template>
+
+	<!-- transform aixm namespace URI, attempting to (re)use prefix 'aixm' -->
+<xsl:template match="src_aixm:*">
+	<xsl:element name="aixm:{local-name()}">
+		<xsl:apply-templates select="@*|node()"/>
+	</xsl:element>
+</xsl:template>
+
+	<!-- transform message namespace URI, attempting to (re)use prefix 'message' -->
+<xsl:template match="src_message:*">
+	<xsl:element name="message:{local-name()}">
+		<xsl:if test="not(ancestor::*)">
+			<xsl:copy-of select="namespace::*[not(local-name()=('aixm','message'))]"/>
+			<xsl:namespace name="aixm" select="'http://www.aixm.aero/schema/5.1'"/>
+			<xsl:namespace name="message" select="'http://www.aixm.aero/schema/5.1/message'"/>
+		</xsl:if>
+		<xsl:apply-templates select="@*|node()"/>
+	</xsl:element>
 </xsl:template>
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -36,7 +36,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<!--identity transformation to copy the unchanged nodes-->
 <xsl:template match="@* | node()">
 	<xsl:copy>
-		<xsl:apply-templates select="@* | node()" />
+		<xsl:apply-templates select="@* | node()"/>
 	</xsl:copy>
 </xsl:template>
 
@@ -76,26 +76,26 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="aixm:StandardLevelColumnTimeSlice[aixm:unitOfMeasurement]">
 	<xsl:choose>
 		<xsl:when test="aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
-			<xsl:copy >
-				<xsl:copy-of select="@gml:id" />
-				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')" />
-				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')" />
-				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')" />
-				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')" />
-				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')" />
-				<xsl:copy-of select="aixm:series" use-when="exists('aixm:series')" />
-				<xsl:copy-of select="aixm:unitOfMeasurement" use-when="exists('aixm:unitOfMeasurement')" />
-				<xsl:copy-of select="aixm:separation" use-when="exists('aixm:separation')" />
-				<xsl:copy-of select="aixm:level" use-when="exists('aixm:level')" />
-				<xsl:copy-of select="aixm:levelTable" use-when="exists('aixm:levelTable')" />
+			<xsl:copy>
+				<xsl:copy-of select="@gml:id"/>
+				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')"/>
+				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')"/>
+				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')"/>
+				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')"/>
+				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')"/>
+				<xsl:copy-of select="aixm:series" use-when="exists('aixm:series')"/>
+				<xsl:copy-of select="aixm:unitOfMeasurement" use-when="exists('aixm:unitOfMeasurement')"/>
+				<xsl:copy-of select="aixm:separation" use-when="exists('aixm:separation')"/>
+				<xsl:copy-of select="aixm:level" use-when="exists('aixm:level')"/>
+				<xsl:copy-of select="aixm:levelTable" use-when="exists('aixm:levelTable')"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
-						<xsl:attribute name="gml:id" select="generate-id()" />
+						<xsl:attribute name="gml:id" select="generate-id()"/>
 						<xsl:element name="aixm:propertyName">unitOfMeasurement</xsl:element>
 						<xsl:element name="aixm:purpose">REMARK</xsl:element>
 						<xsl:element name="aixm:translatedNote">
 							<xsl:element name="aixm:LinguisticNote">
-								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')" />
+								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')"/>
 								<xsl:element name="aixm:note">
 									<xsl:value-of select="aixm:unitOfMeasurement/@nilReason"/>
 								</xsl:element>
@@ -103,12 +103,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')" />
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')" />
+				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
+				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="." />
+			<xsl:copy-of select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -116,26 +116,26 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="aixm:MarkingBuoyTimeSlice[aixm:designator]">
 	<xsl:choose>
 		<xsl:when test="aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
-			<xsl:copy >
-				<xsl:copy-of select="@gml:id" />
-				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')" />
-				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')" />
-				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')" />
-				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')" />
-				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')" />
-				<xsl:copy-of select="aixm:designator" use-when="exists('aixm:designator')" />
-				<xsl:copy-of select="aixm:type" use-when="exists('aixm:type')" />
-				<xsl:copy-of select="aixm:colour" use-when="exists('aixm:colour')" />
-				<xsl:copy-of select="aixm:theSeaplaneLandingArea" use-when="exists('aixm:theSeaplaneLandingArea')" />
-				<xsl:copy-of select="aixm:location" use-when="exists('aixm:location')" />
+			<xsl:copy>
+				<xsl:copy-of select="@gml:id"/>
+				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')"/>
+				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')"/>
+				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')"/>
+				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')"/>
+				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')"/>
+				<xsl:copy-of select="aixm:designator" use-when="exists('aixm:designator')"/>
+				<xsl:copy-of select="aixm:type" use-when="exists('aixm:type')"/>
+				<xsl:copy-of select="aixm:colour" use-when="exists('aixm:colour')"/>
+				<xsl:copy-of select="aixm:theSeaplaneLandingArea" use-when="exists('aixm:theSeaplaneLandingArea')"/>
+				<xsl:copy-of select="aixm:location" use-when="exists('aixm:location')"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
-						<xsl:attribute name="gml:id" select="generate-id()" />
+						<xsl:attribute name="gml:id" select="generate-id()"/>
 						<xsl:element name="aixm:propertyName">designator</xsl:element>
 						<xsl:element name="aixm:purpose">REMARK</xsl:element>
 						<xsl:element name="aixm:translatedNote">
 							<xsl:element name="aixm:LinguisticNote">
-								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')" />
+								<xsl:attribute name="gml:id" select="concat(generate-id(),'10')"/>
 								<xsl:element name="aixm:note">
 									<xsl:value-of select="aixm:designator/@nilReason"/>
 								</xsl:element>
@@ -143,12 +143,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')" />
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')" />
+				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
+				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="." />
+			<xsl:copy-of select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -157,29 +157,29 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:choose>
 		<xsl:when test="aixm:routeIndicator[@nilReason] or aixm:referencePathIdentifier[@nilReason] or aixm:codeICAO[@nilReason]">
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id" />
-				<xsl:copy-of select="aixm:horizontalAlarmLimit" use-when="exists('aixm:horizontalAlarmLimit')" />
-				<xsl:copy-of select="aixm:verticalAlarmLimit" use-when="exists('aixm:verticalAlarmLimit')" />
-				<xsl:copy-of select="aixm:thresholdCourseWidth" use-when="exists('aixm:thresholdCourseWidth')" />
-				<xsl:copy-of select="aixm:lengthOffset" use-when="exists('aixm:lengthOffset')" />
-				<xsl:copy-of select="aixm:CRCRemainder" use-when="exists('aixm:CRCRemainder')" />
-				<xsl:copy-of select="aixm:operationType" use-when="exists('aixm:operationType')" />
-				<xsl:copy-of select="aixm:serviceProviderSBAS" use-when="exists('aixm:serviceProviderSBAS')" />
-				<xsl:copy-of select="aixm:approachPerformanceDesignator" use-when="exists('aixm:approachPerformanceDesignator')" />
-				<xsl:copy-of select="aixm:routeIndicator" use-when="exists('aixm:routeIndicator')" />
-				<xsl:copy-of select="aixm:referencePathDataSelector" use-when="exists('aixm:referencePathDataSelector')" />
-				<xsl:copy-of select="aixm:referencePathIdentifier" use-when="exists('aixm:referencePathIdentifier')" />
-				<xsl:copy-of select="aixm:codeICAO" use-when="exists('aixm:codeICAO')" />
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')" />
+				<xsl:copy-of select="@gml:id"/>
+				<xsl:copy-of select="aixm:horizontalAlarmLimit" use-when="exists('aixm:horizontalAlarmLimit')"/>
+				<xsl:copy-of select="aixm:verticalAlarmLimit" use-when="exists('aixm:verticalAlarmLimit')"/>
+				<xsl:copy-of select="aixm:thresholdCourseWidth" use-when="exists('aixm:thresholdCourseWidth')"/>
+				<xsl:copy-of select="aixm:lengthOffset" use-when="exists('aixm:lengthOffset')"/>
+				<xsl:copy-of select="aixm:CRCRemainder" use-when="exists('aixm:CRCRemainder')"/>
+				<xsl:copy-of select="aixm:operationType" use-when="exists('aixm:operationType')"/>
+				<xsl:copy-of select="aixm:serviceProviderSBAS" use-when="exists('aixm:serviceProviderSBAS')"/>
+				<xsl:copy-of select="aixm:approachPerformanceDesignator" use-when="exists('aixm:approachPerformanceDesignator')"/>
+				<xsl:copy-of select="aixm:routeIndicator" use-when="exists('aixm:routeIndicator')"/>
+				<xsl:copy-of select="aixm:referencePathDataSelector" use-when="exists('aixm:referencePathDataSelector')"/>
+				<xsl:copy-of select="aixm:referencePathIdentifier" use-when="exists('aixm:referencePathIdentifier')"/>
+				<xsl:copy-of select="aixm:codeICAO" use-when="exists('aixm:codeICAO')"/>
+				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
 				<xsl:if test="aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
-							<xsl:attribute name="gml:id" select="concat('g', generate-id())" />
+							<xsl:attribute name="gml:id" select="concat('g', generate-id())"/>
 							<xsl:element name="aixm:propertyName">routeIndicator</xsl:element>
 							<xsl:element name="aixm:purpose">REMARK</xsl:element>
 							<xsl:element name="aixm:translatedNote">
 								<xsl:element name="aixm:LinguisticNote">
-									<xsl:attribute name="gml:id" select="concat('g', generate-id(),'10')" />
+									<xsl:attribute name="gml:id" select="concat('g', generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
 										<xsl:value-of select="aixm:routeIndicator/@nilReason"/>
 									</xsl:element>
@@ -191,12 +191,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				<xsl:if test="aixm:referencePathIdentifier[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
-							<xsl:attribute name="gml:id" select="concat('a',generate-id())" />
+							<xsl:attribute name="gml:id" select="concat('a',generate-id())"/>
 							<xsl:element name="aixm:propertyName">referencePathIdentifier</xsl:element>
 							<xsl:element name="aixm:purpose">REMARK</xsl:element>
 							<xsl:element name="aixm:translatedNote">
 								<xsl:element name="aixm:LinguisticNote">
-									<xsl:attribute name="gml:id" select="concat('a',generate-id(),'10')" />
+									<xsl:attribute name="gml:id" select="concat('a',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
 										<xsl:value-of select="aixm:referencePathIdentifier/@nilReason"/>
 									</xsl:element>
@@ -208,12 +208,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				<xsl:if test="aixm:codeICAO[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
-							<xsl:attribute name="gml:id" select="concat('d',generate-id())" />
+							<xsl:attribute name="gml:id" select="concat('d',generate-id())"/>
 							<xsl:element name="aixm:propertyName">codeICAO</xsl:element>
 							<xsl:element name="aixm:purpose">REMARK</xsl:element>
 							<xsl:element name="aixm:translatedNote">
 								<xsl:element name="aixm:LinguisticNote">
-									<xsl:attribute name="gml:id" select="concat('d',generate-id(),'10')" />
+									<xsl:attribute name="gml:id" select="concat('d',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
 										<xsl:value-of select="aixm:codeICAO/@nilReason"/>
 									</xsl:element>
@@ -222,11 +222,11 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')" />
+				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="." />
+			<xsl:copy-of select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -257,21 +257,21 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="aixm:Note[aixm:propertyName]">
 	<xsl:choose>
 		<xsl:when test="aixm:propertyName[matches(text(),'^[a-z][A-Za-z]*$')]">
-			<xsl:copy-of select="." />
+			<xsl:copy-of select="."/>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id" />
-				<xsl:copy-of select="aixm:purpose" use-when="exists('aixm:purpose')" />
+				<xsl:copy-of select="@gml:id"/>
+				<xsl:copy-of select="aixm:purpose" use-when="exists('aixm:purpose')"/>
 				<xsl:element name="aixm:translatedNote">
 					<xsl:element name="aixm:LinguisticNote">
-						<xsl:attribute name="gml:id" select="generate-id()" />
+						<xsl:attribute name="gml:id" select="generate-id()"/>
 						<xsl:element name="aixm:note">
 							<xsl:text>value-of Note.propertyName: </xsl:text><xsl:value-of select="aixm:propertyName"/>
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:translatedNote" use-when="exists('aixm:translatedNote')" />
+				<xsl:copy-of select="aixm:translatedNote" use-when="exists('aixm:translatedNote')"/>
 			</xsl:copy>
 		</xsl:otherwise>
 	</xsl:choose>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -99,6 +99,27 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:element>
 </xsl:template>
 
+	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
+<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
+	<xsl:element name="aixm:{local-name()}">
+		<xsl:value-of select="concat('OTHER:',.)"/>
+	</xsl:element>
+</xsl:template>
+
+	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
+<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='ELECTRIC']">
+	<xsl:element name="aixm:{local-name()}">
+		<xsl:value-of select="concat('OTHER:',.)"/>
+	</xsl:element>
+</xsl:template>
+
+	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
+<xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVSM']">
+	<xsl:element name="aixm:{local-name()}">
+		<xsl:text>VFR_RVMS</xsl:text>
+	</xsl:element>
+</xsl:template>
+
 	<!--script implementing change proposal AIXM-146 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-146 )-->
 <xsl:template match="src_aixm:StandardLevelColumnTimeSlice[src_aixm:unitOfMeasurement]">
 	<xsl:choose>
@@ -256,27 +277,6 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 			<xsl:apply-templates select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
-</xsl:template>
-
-	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
-<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="concat('OTHER:',.)"/>
-	</xsl:element>
-</xsl:template>
-
-	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
-<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='ELECTRIC']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="concat('OTHER:',.)"/>
-	</xsl:element>
-</xsl:template>
-
-	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
-<xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVSM']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>VFR_RVMS</xsl:text>
-	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-164 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-164 )-->

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -30,7 +30,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	-->
 <!-- Component: XSLT scripts: backward mapping (AIXM 5.1.1 to AIXM 5.1) -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:aixm="http://www.aixm.aero/schema/5.1" xmlns:gml="http://www.opengis.net/gml/3.2">
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:aixm="http://www.aixm.aero/schema/5.1"
+                xmlns:gml="http://www.opengis.net/gml/3.2">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -48,41 +48,41 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->
 <xsl:template match="src_aixm:RulesProcedures//src_aixm:title[text()='HOLDING_APPROACH_DEPARTURE_PROCEDURES']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>HOLDING_ APPROACH_DEPARTURE_PROCEDURES</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>AGNIS </xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>AGNIS_STOP </xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>IN_DEMOLITION </xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
 <xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='LTP']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>OTHER:LTP</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-146 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-146 )-->
 <xsl:template match="src_aixm:StandardLevelColumnTimeSlice[src_aixm:unitOfMeasurement]">
 	<xsl:choose>
 		<xsl:when test="src_aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
-			<xsl:copy>
+			<xsl:element name="aixm:{local-name()}">
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="gml:validTime"/>
 				<xsl:apply-templates select="src_aixm:interpretation"/>
@@ -111,7 +111,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				</xsl:element>
 				<xsl:apply-templates select="src_aixm:annotation"/>
 				<xsl:apply-templates select="src_aixm:extension"/>
-			</xsl:copy>
+			</xsl:element>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:apply-templates select="."/>
@@ -122,7 +122,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="src_aixm:MarkingBuoyTimeSlice[src_aixm:designator]">
 	<xsl:choose>
 		<xsl:when test="src_aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
-			<xsl:copy>
+			<xsl:element name="aixm:{local-name()}">
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="gml:validTime"/>
 				<xsl:apply-templates select="src_aixm:interpretation"/>
@@ -151,7 +151,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				</xsl:element>
 				<xsl:apply-templates select="src_aixm:annotation"/>
 				<xsl:apply-templates select="src_aixm:extension"/>
-			</xsl:copy>
+			</xsl:element>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:apply-templates select="."/>
@@ -162,7 +162,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="src_aixm:FASDataBlock">
 	<xsl:choose>
 		<xsl:when test="src_aixm:routeIndicator[@nilReason] or src_aixm:referencePathIdentifier[@nilReason] or src_aixm:codeICAO[@nilReason]">
-			<xsl:copy>
+			<xsl:element name="aixm:{local-name()}">
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="src_aixm:horizontalAlarmLimit"/>
 				<xsl:apply-templates select="src_aixm:verticalAlarmLimit"/>
@@ -229,7 +229,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 					</xsl:element>
 				</xsl:if>
 				<xsl:apply-templates select="src_aixm:extension"/>
-			</xsl:copy>
+			</xsl:element>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:apply-templates select="."/>
@@ -239,23 +239,23 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
 <xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('IIIA','IIIB','IIIC')]">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:value-of select="concat('OTHER:',.)"/>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
 <xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='ELECTRIC']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:value-of select="concat('OTHER:',.)"/>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
 <xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVSM']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>VFR_RVMS</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-164 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-164 )-->
@@ -266,7 +266,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 			<xsl:apply-templates select="."/>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy>
+			<xsl:element name="aixm:{local-name()}">
 				<xsl:apply-templates select="@gml:id"/>
 				<xsl:apply-templates select="src_aixm:purpose"/>
 				<xsl:element name="aixm:translatedNote">
@@ -278,7 +278,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 					</xsl:element>
 				</xsl:element>
 				<xsl:apply-templates select="src_aixm:translatedNote"/>
-			</xsl:copy>
+			</xsl:element>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -82,17 +82,17 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:choose>
 		<xsl:when test="aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="gml:validTime"/>
-				<xsl:copy-of select="aixm:interpretation"/>
-				<xsl:copy-of select="aixm:sequenceNumber"/>
-				<xsl:copy-of select="aixm:correctionNumber"/>
-				<xsl:copy-of select="aixm:featureLifetime"/>
-				<xsl:copy-of select="aixm:series"/>
-				<xsl:copy-of select="aixm:unitOfMeasurement"/>
-				<xsl:copy-of select="aixm:separation"/>
-				<xsl:copy-of select="aixm:level"/>
-				<xsl:copy-of select="aixm:levelTable"/>
+				<xsl:apply-templates select="@gml:id"/>
+				<xsl:apply-templates select="gml:validTime"/>
+				<xsl:apply-templates select="aixm:interpretation"/>
+				<xsl:apply-templates select="aixm:sequenceNumber"/>
+				<xsl:apply-templates select="aixm:correctionNumber"/>
+				<xsl:apply-templates select="aixm:featureLifetime"/>
+				<xsl:apply-templates select="aixm:series"/>
+				<xsl:apply-templates select="aixm:unitOfMeasurement"/>
+				<xsl:apply-templates select="aixm:separation"/>
+				<xsl:apply-templates select="aixm:level"/>
+				<xsl:apply-templates select="aixm:levelTable"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -108,12 +108,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation"/>
-				<xsl:copy-of select="aixm:extension"/>
+				<xsl:apply-templates select="aixm:annotation"/>
+				<xsl:apply-templates select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="."/>
+			<xsl:apply-templates select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -122,17 +122,17 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:choose>
 		<xsl:when test="aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="gml:validTime"/>
-				<xsl:copy-of select="aixm:interpretation"/>
-				<xsl:copy-of select="aixm:sequenceNumber"/>
-				<xsl:copy-of select="aixm:correctionNumber"/>
-				<xsl:copy-of select="aixm:featureLifetime"/>
-				<xsl:copy-of select="aixm:designator"/>
-				<xsl:copy-of select="aixm:type"/>
-				<xsl:copy-of select="aixm:colour"/>
-				<xsl:copy-of select="aixm:theSeaplaneLandingArea"/>
-				<xsl:copy-of select="aixm:location"/>
+				<xsl:apply-templates select="@gml:id"/>
+				<xsl:apply-templates select="gml:validTime"/>
+				<xsl:apply-templates select="aixm:interpretation"/>
+				<xsl:apply-templates select="aixm:sequenceNumber"/>
+				<xsl:apply-templates select="aixm:correctionNumber"/>
+				<xsl:apply-templates select="aixm:featureLifetime"/>
+				<xsl:apply-templates select="aixm:designator"/>
+				<xsl:apply-templates select="aixm:type"/>
+				<xsl:apply-templates select="aixm:colour"/>
+				<xsl:apply-templates select="aixm:theSeaplaneLandingArea"/>
+				<xsl:apply-templates select="aixm:location"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -148,12 +148,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation"/>
-				<xsl:copy-of select="aixm:extension"/>
+				<xsl:apply-templates select="aixm:annotation"/>
+				<xsl:apply-templates select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="."/>
+			<xsl:apply-templates select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -162,20 +162,20 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:choose>
 		<xsl:when test="aixm:routeIndicator[@nilReason] or aixm:referencePathIdentifier[@nilReason] or aixm:codeICAO[@nilReason]">
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="aixm:horizontalAlarmLimit"/>
-				<xsl:copy-of select="aixm:verticalAlarmLimit"/>
-				<xsl:copy-of select="aixm:thresholdCourseWidth"/>
-				<xsl:copy-of select="aixm:lengthOffset"/>
-				<xsl:copy-of select="aixm:CRCRemainder"/>
-				<xsl:copy-of select="aixm:operationType"/>
-				<xsl:copy-of select="aixm:serviceProviderSBAS"/>
-				<xsl:copy-of select="aixm:approachPerformanceDesignator"/>
-				<xsl:copy-of select="aixm:routeIndicator"/>
-				<xsl:copy-of select="aixm:referencePathDataSelector"/>
-				<xsl:copy-of select="aixm:referencePathIdentifier"/>
-				<xsl:copy-of select="aixm:codeICAO"/>
-				<xsl:copy-of select="aixm:annotation"/>
+				<xsl:apply-templates select="@gml:id"/>
+				<xsl:apply-templates select="aixm:horizontalAlarmLimit"/>
+				<xsl:apply-templates select="aixm:verticalAlarmLimit"/>
+				<xsl:apply-templates select="aixm:thresholdCourseWidth"/>
+				<xsl:apply-templates select="aixm:lengthOffset"/>
+				<xsl:apply-templates select="aixm:CRCRemainder"/>
+				<xsl:apply-templates select="aixm:operationType"/>
+				<xsl:apply-templates select="aixm:serviceProviderSBAS"/>
+				<xsl:apply-templates select="aixm:approachPerformanceDesignator"/>
+				<xsl:apply-templates select="aixm:routeIndicator"/>
+				<xsl:apply-templates select="aixm:referencePathDataSelector"/>
+				<xsl:apply-templates select="aixm:referencePathIdentifier"/>
+				<xsl:apply-templates select="aixm:codeICAO"/>
+				<xsl:apply-templates select="aixm:annotation"/>
 				<xsl:if test="aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
@@ -227,11 +227,11 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:copy-of select="aixm:extension"/>
+				<xsl:apply-templates select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
-			<xsl:copy-of select="."/>
+			<xsl:apply-templates select="."/>
 		</xsl:otherwise>
 	</xsl:choose>
 </xsl:template>
@@ -262,12 +262,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 <xsl:template match="aixm:Note[aixm:propertyName]">
 	<xsl:choose>
 		<xsl:when test="aixm:propertyName[matches(text(),'^[a-z][A-Za-z]*$')]">
-			<xsl:copy-of select="."/>
+			<xsl:apply-templates select="."/>
 		</xsl:when>
 		<xsl:otherwise>
 			<xsl:copy>
-				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="aixm:purpose"/>
+				<xsl:apply-templates select="@gml:id"/>
+				<xsl:apply-templates select="aixm:purpose"/>
 				<xsl:element name="aixm:translatedNote">
 					<xsl:element name="aixm:LinguisticNote">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -276,7 +276,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:translatedNote"/>
+				<xsl:apply-templates select="aixm:translatedNote"/>
 			</xsl:copy>
 		</xsl:otherwise>
 	</xsl:choose>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -22,9 +22,9 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		http://www.opensource.org/licenses/bsd-license.php
 		==========================================
 		Technical note:
-			* The scripts have been tested using Saxon Home Edition 9.6.0.5. The transition from Xalan to Saxon was a prerequisite for using a new function implemented with XSLT 2.0 (i.e fn:matches) 
+			* The scripts have been tested using Saxon Home Edition 9.6.0.5. The transition from Xalan to Saxon was a prerequisite for using a new function implemented with XSLT 2.0 (i.e fn:matches)
 			needed for the implementation of the change proposals. For more details and download links please the following link: http://saxon.sourceforge.net/ .
-			* When the script is run using a Java extension the following warning will be prompted: The child axis starting at an attribute node will never select anything. 
+			* When the script is run using a Java extension the following warning will be prompted: The child axis starting at an attribute node will never select anything.
 			This warning is a bug from Saxon which doesn't affect the output.
 		==========================================
 	-->
@@ -208,16 +208,16 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				<xsl:if test="aixm:codeICAO[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
-						<xsl:attribute name="gml:id" select="concat('d',generate-id())" />
+							<xsl:attribute name="gml:id" select="concat('d',generate-id())" />
 							<xsl:element name="aixm:propertyName">codeICAO</xsl:element>
-								<xsl:element name="aixm:purpose">REMARK</xsl:element>
-									<xsl:element name="aixm:translatedNote">
-										<xsl:element name="aixm:LinguisticNote">
-										<xsl:attribute name="gml:id" select="concat('d',generate-id(),'10')" />
-											<xsl:element name="aixm:note">
-												<xsl:value-of select="aixm:codeICAO/@nilReason"/>
-											</xsl:element>
-										</xsl:element>
+							<xsl:element name="aixm:purpose">REMARK</xsl:element>
+							<xsl:element name="aixm:translatedNote">
+								<xsl:element name="aixm:LinguisticNote">
+									<xsl:attribute name="gml:id" select="concat('d',generate-id(),'10')" />
+									<xsl:element name="aixm:note">
+										<xsl:value-of select="aixm:codeICAO/@nilReason"/>
+									</xsl:element>
+								</xsl:element>
 							</xsl:element>
 						</xsl:element>
 					</xsl:element>
@@ -263,14 +263,14 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 			<xsl:copy>
 				<xsl:copy-of select="@gml:id" />
 				<xsl:copy-of select="aixm:purpose" use-when="exists('aixm:purpose')" />
-					<xsl:element name="aixm:translatedNote">
-						<xsl:element name="aixm:LinguisticNote">
-							<xsl:attribute name="gml:id" select="generate-id()" />
-								<xsl:element name="aixm:note">
-									<xsl:text>value-of Note.propertyName: </xsl:text><xsl:value-of select="aixm:propertyName"/>
-								</xsl:element>
+				<xsl:element name="aixm:translatedNote">
+					<xsl:element name="aixm:LinguisticNote">
+						<xsl:attribute name="gml:id" select="generate-id()" />
+						<xsl:element name="aixm:note">
+							<xsl:text>value-of Note.propertyName: </xsl:text><xsl:value-of select="aixm:propertyName"/>
 						</xsl:element>
 					</xsl:element>
+				</xsl:element>
 				<xsl:copy-of select="aixm:translatedNote" use-when="exists('aixm:translatedNote')" />
 			</xsl:copy>
 		</xsl:otherwise>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -34,9 +34,9 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->
-<xsl:template match="@* | node()">
+<xsl:template match="@*|node()">
 	<xsl:copy>
-		<xsl:apply-templates select="@* | node()"/>
+		<xsl:apply-templates select="@*|node()"/>
 	</xsl:copy>
 </xsl:template>
 
@@ -174,12 +174,12 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 				<xsl:if test="aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
-							<xsl:attribute name="gml:id" select="concat('g', generate-id())"/>
+							<xsl:attribute name="gml:id" select="concat('g',generate-id())"/>
 							<xsl:element name="aixm:propertyName">routeIndicator</xsl:element>
 							<xsl:element name="aixm:purpose">REMARK</xsl:element>
 							<xsl:element name="aixm:translatedNote">
 								<xsl:element name="aixm:LinguisticNote">
-									<xsl:attribute name="gml:id" select="concat('g', generate-id(),'10')"/>
+									<xsl:attribute name="gml:id" select="concat('g',generate-id(),'10')"/>
 									<xsl:element name="aixm:note">
 										<xsl:value-of select="aixm:routeIndicator/@nilReason"/>
 									</xsl:element>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(backward)_v1.0.xslt
@@ -83,16 +83,16 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		<xsl:when test="aixm:unitOfMeasurement[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
 				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')"/>
-				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')"/>
-				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')"/>
-				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')"/>
-				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')"/>
-				<xsl:copy-of select="aixm:series" use-when="exists('aixm:series')"/>
-				<xsl:copy-of select="aixm:unitOfMeasurement" use-when="exists('aixm:unitOfMeasurement')"/>
-				<xsl:copy-of select="aixm:separation" use-when="exists('aixm:separation')"/>
-				<xsl:copy-of select="aixm:level" use-when="exists('aixm:level')"/>
-				<xsl:copy-of select="aixm:levelTable" use-when="exists('aixm:levelTable')"/>
+				<xsl:copy-of select="gml:validTime"/>
+				<xsl:copy-of select="aixm:interpretation"/>
+				<xsl:copy-of select="aixm:sequenceNumber"/>
+				<xsl:copy-of select="aixm:correctionNumber"/>
+				<xsl:copy-of select="aixm:featureLifetime"/>
+				<xsl:copy-of select="aixm:series"/>
+				<xsl:copy-of select="aixm:unitOfMeasurement"/>
+				<xsl:copy-of select="aixm:separation"/>
+				<xsl:copy-of select="aixm:level"/>
+				<xsl:copy-of select="aixm:levelTable"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -108,8 +108,8 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
+				<xsl:copy-of select="aixm:annotation"/>
+				<xsl:copy-of select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -123,16 +123,16 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		<xsl:when test="aixm:designator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 			<xsl:copy>
 				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="gml:validTime" use-when="exists('gml:validTime')"/>
-				<xsl:copy-of select="aixm:interpretation" use-when="exists('aixm:interpretation')"/>
-				<xsl:copy-of select="aixm:sequenceNumber" use-when="exists('aixm:sequenceNumber')"/>
-				<xsl:copy-of select="aixm:correctionNumber" use-when="exists('aixm:correctionNumber')"/>
-				<xsl:copy-of select="aixm:featureLifetime" use-when="exists('aixm:featureLifetime')"/>
-				<xsl:copy-of select="aixm:designator" use-when="exists('aixm:designator')"/>
-				<xsl:copy-of select="aixm:type" use-when="exists('aixm:type')"/>
-				<xsl:copy-of select="aixm:colour" use-when="exists('aixm:colour')"/>
-				<xsl:copy-of select="aixm:theSeaplaneLandingArea" use-when="exists('aixm:theSeaplaneLandingArea')"/>
-				<xsl:copy-of select="aixm:location" use-when="exists('aixm:location')"/>
+				<xsl:copy-of select="gml:validTime"/>
+				<xsl:copy-of select="aixm:interpretation"/>
+				<xsl:copy-of select="aixm:sequenceNumber"/>
+				<xsl:copy-of select="aixm:correctionNumber"/>
+				<xsl:copy-of select="aixm:featureLifetime"/>
+				<xsl:copy-of select="aixm:designator"/>
+				<xsl:copy-of select="aixm:type"/>
+				<xsl:copy-of select="aixm:colour"/>
+				<xsl:copy-of select="aixm:theSeaplaneLandingArea"/>
+				<xsl:copy-of select="aixm:location"/>
 				<xsl:element name="aixm:annotation">
 					<xsl:element name="aixm:Note">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -148,8 +148,8 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
+				<xsl:copy-of select="aixm:annotation"/>
+				<xsl:copy-of select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -163,19 +163,19 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		<xsl:when test="aixm:routeIndicator[@nilReason] or aixm:referencePathIdentifier[@nilReason] or aixm:codeICAO[@nilReason]">
 			<xsl:copy>
 				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="aixm:horizontalAlarmLimit" use-when="exists('aixm:horizontalAlarmLimit')"/>
-				<xsl:copy-of select="aixm:verticalAlarmLimit" use-when="exists('aixm:verticalAlarmLimit')"/>
-				<xsl:copy-of select="aixm:thresholdCourseWidth" use-when="exists('aixm:thresholdCourseWidth')"/>
-				<xsl:copy-of select="aixm:lengthOffset" use-when="exists('aixm:lengthOffset')"/>
-				<xsl:copy-of select="aixm:CRCRemainder" use-when="exists('aixm:CRCRemainder')"/>
-				<xsl:copy-of select="aixm:operationType" use-when="exists('aixm:operationType')"/>
-				<xsl:copy-of select="aixm:serviceProviderSBAS" use-when="exists('aixm:serviceProviderSBAS')"/>
-				<xsl:copy-of select="aixm:approachPerformanceDesignator" use-when="exists('aixm:approachPerformanceDesignator')"/>
-				<xsl:copy-of select="aixm:routeIndicator" use-when="exists('aixm:routeIndicator')"/>
-				<xsl:copy-of select="aixm:referencePathDataSelector" use-when="exists('aixm:referencePathDataSelector')"/>
-				<xsl:copy-of select="aixm:referencePathIdentifier" use-when="exists('aixm:referencePathIdentifier')"/>
-				<xsl:copy-of select="aixm:codeICAO" use-when="exists('aixm:codeICAO')"/>
-				<xsl:copy-of select="aixm:annotation" use-when="exists('aixm:annotation')"/>
+				<xsl:copy-of select="aixm:horizontalAlarmLimit"/>
+				<xsl:copy-of select="aixm:verticalAlarmLimit"/>
+				<xsl:copy-of select="aixm:thresholdCourseWidth"/>
+				<xsl:copy-of select="aixm:lengthOffset"/>
+				<xsl:copy-of select="aixm:CRCRemainder"/>
+				<xsl:copy-of select="aixm:operationType"/>
+				<xsl:copy-of select="aixm:serviceProviderSBAS"/>
+				<xsl:copy-of select="aixm:approachPerformanceDesignator"/>
+				<xsl:copy-of select="aixm:routeIndicator"/>
+				<xsl:copy-of select="aixm:referencePathDataSelector"/>
+				<xsl:copy-of select="aixm:referencePathIdentifier"/>
+				<xsl:copy-of select="aixm:codeICAO"/>
+				<xsl:copy-of select="aixm:annotation"/>
 				<xsl:if test="aixm:routeIndicator[@nilReason[text()=('inapplicable','missing','template','unknown','withheld')]]">
 					<xsl:element name="aixm:annotation">
 						<xsl:element name="aixm:Note">
@@ -227,7 +227,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:if>
-				<xsl:copy-of select="aixm:extension" use-when="exists('aixm:extension')"/>
+				<xsl:copy-of select="aixm:extension"/>
 			</xsl:copy>
 		</xsl:when>
 		<xsl:otherwise>
@@ -267,7 +267,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		<xsl:otherwise>
 			<xsl:copy>
 				<xsl:copy-of select="@gml:id"/>
-				<xsl:copy-of select="aixm:purpose" use-when="exists('aixm:purpose')"/>
+				<xsl:copy-of select="aixm:purpose"/>
 				<xsl:element name="aixm:translatedNote">
 					<xsl:element name="aixm:LinguisticNote">
 						<xsl:attribute name="gml:id" select="generate-id()"/>
@@ -276,7 +276,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 						</xsl:element>
 					</xsl:element>
 				</xsl:element>
-				<xsl:copy-of select="aixm:translatedNote" use-when="exists('aixm:translatedNote')"/>
+				<xsl:copy-of select="aixm:translatedNote"/>
 			</xsl:copy>
 		</xsl:otherwise>
 	</xsl:choose>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -70,42 +70,23 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	</xsl:element>
 </xsl:template>
 
-<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS ']">
+<xsl:template match="
+		src_aixm:AircraftStand        //src_aixm:visualDockingSystem[text()=('AGNIS ','AGNIS_STOP ')]|
+		src_aixm:VerticalStructurePart/ src_aixm:constructionStatus [text()= 'IN_DEMOLITION '       ]">
 	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>AGNIS</xsl:text>
-	</xsl:element>
-</xsl:template>
-
-<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP ']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>AGNIS_STOP</xsl:text>
-	</xsl:element>
-</xsl:template>
-
-<xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION ']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>IN_DEMOLITION</xsl:text>
+		<xsl:value-of select="translate(text(),' ','')"/>
 	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
-<xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='OTHER:LTP']">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:text>LTP</xsl:text>
-	</xsl:element>
-</xsl:template>
-
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
-<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('OTHER:IIIA','OTHER:IIIB','OTHER:IIIC')]">
-	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="substring-after(.,'OTHER:')"/>
-	</xsl:element>
-</xsl:template>
-
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
-<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='OTHER:ELECTRIC']">
+<xsl:template match="
+		src_aixm:TerminalSegmentPoint  //src_aixm:role             [text()= 'OTHER:LTP'                            ]|
+		src_aixm:Navaid                //src_aixm:signalPerformance[text()=('OTHER:IIIA','OTHER:IIIB','OTHER:IIIC')]|
+		src_aixm:AircraftCharacteristic//src_aixm:engine           [text()= 'OTHER:ELECTRIC'                       ]">
 	<xsl:element name="aixm:{local-name()}">
-		<xsl:value-of select="substring-after(.,'OTHER:')"/>
+		<xsl:value-of select="substring-after(text(),'OTHER:')"/>
 	</xsl:element>
 </xsl:template>
 

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -32,14 +32,35 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:fn="http://www.w3.org/2005/xpath-functions"
                 xmlns:src_aixm="http://www.aixm.aero/schema/5.1"
-                xmlns:aixm="http://www.aixm.aero/schema/5.1">
+                xmlns:src_message="http://www.aixm.aero/schema/5.1/message"
+                xmlns:aixm="http://www.aixm.aero/schema/5.1.1"
+                xmlns:message="http://www.aixm.aero/schema/5.1.1/message">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->
 <xsl:template match="@*|node()">
-	<xsl:copy>
+	<xsl:copy copy-namespaces="no">
 		<xsl:apply-templates select="@*|node()"/>
 	</xsl:copy>
+</xsl:template>
+
+	<!-- transform aixm namespace URI, attempting to (re)use prefix 'aixm' -->
+<xsl:template match="src_aixm:*">
+	<xsl:element name="aixm:{local-name()}">
+		<xsl:apply-templates select="@*|node()"/>
+	</xsl:element>
+</xsl:template>
+
+	<!-- transform message namespace URI, attempting to (re)use prefix 'message' -->
+<xsl:template match="src_message:*">
+	<xsl:element name="message:{local-name()}">
+		<xsl:if test="not(ancestor::*)">
+			<xsl:copy-of select="namespace::*[not(local-name()=('aixm','message'))]"/>
+			<xsl:namespace name="aixm" select="'http://www.aixm.aero/schema/5.1.1'"/>
+			<xsl:namespace name="message" select="'http://www.aixm.aero/schema/5.1.1/message'"/>
+		</xsl:if>
+		<xsl:apply-templates select="@*|node()"/>
+	</xsl:element>
 </xsl:template>
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -31,6 +31,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:src_aixm="http://www.aixm.aero/schema/5.1"
                 xmlns:aixm="http://www.aixm.aero/schema/5.1">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
@@ -42,53 +43,53 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 </xsl:template>
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->
-<xsl:template match="aixm:RulesProcedures//aixm:title[text()='HOLDING_ APPROACH_DEPARTURE_PROCEDURES']">
+<xsl:template match="src_aixm:RulesProcedures//src_aixm:title[text()='HOLDING_ APPROACH_DEPARTURE_PROCEDURES']">
 	<xsl:copy>
 		<xsl:text>HOLDING_APPROACH_DEPARTURE_PROCEDURES</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:AircraftStand//aixm:visualDockingSystem[text()='AGNIS ']">
+<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS ']">
 	<xsl:copy>
 		<xsl:text>AGNIS</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:AircraftStand//aixm:visualDockingSystem[text()='AGNIS_STOP ']">
+<xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP ']">
 	<xsl:copy>
 		<xsl:text>AGNIS_STOP</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
-<xsl:template match="aixm:VerticalStructurePart/aixm:constructionStatus[text()='IN_DEMOLITION ']">
+<xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION ']">
 	<xsl:copy>
 		<xsl:text>IN_DEMOLITION</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
-<xsl:template match="aixm:TerminalSegmentPoint//aixm:role[text()='OTHER:LTP']">
+<xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='OTHER:LTP']">
 	<xsl:copy>
 		<xsl:text>LTP</xsl:text>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
-<xsl:template match="aixm:Navaid//aixm:signalPerformance[text()=('OTHER:IIIA','OTHER:IIIB','OTHER:IIIC')]">
+<xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('OTHER:IIIA','OTHER:IIIB','OTHER:IIIC')]">
 	<xsl:copy>
 		<xsl:value-of select="substring-after(.,'OTHER:')"/>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
-<xsl:template match="aixm:AircraftCharacteristic//aixm:engine[text()='OTHER:ELECTRIC']">
+<xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='OTHER:ELECTRIC']">
 	<xsl:copy>
 		<xsl:value-of select="substring-after(.,'OTHER:')"/>
 	</xsl:copy>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
-<xsl:template match="aixm:StandardLevelTable//aixm:name[text()='VFR_RVMS']">
+<xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVMS']">
 	<xsl:copy>
 		<xsl:text>VFR_RVSM</xsl:text>
 	</xsl:copy>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -44,55 +44,55 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 
 	<!-- script implementing change proposal AIXM-139 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-139 )-->
 <xsl:template match="src_aixm:RulesProcedures//src_aixm:title[text()='HOLDING_ APPROACH_DEPARTURE_PROCEDURES']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>HOLDING_APPROACH_DEPARTURE_PROCEDURES</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS ']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>AGNIS</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:AircraftStand//src_aixm:visualDockingSystem[text()='AGNIS_STOP ']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>AGNIS_STOP</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 <xsl:template match="src_aixm:VerticalStructurePart/src_aixm:constructionStatus[text()='IN_DEMOLITION ']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>IN_DEMOLITION</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-143 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-143 )-->
 <xsl:template match="src_aixm:TerminalSegmentPoint//src_aixm:role[text()='OTHER:LTP']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>LTP</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-147 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-147 )-->
 <xsl:template match="src_aixm:Navaid//src_aixm:signalPerformance[text()=('OTHER:IIIA','OTHER:IIIB','OTHER:IIIC')]">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:value-of select="substring-after(.,'OTHER:')"/>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-150 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-150 )-->
 <xsl:template match="src_aixm:AircraftCharacteristic//src_aixm:engine[text()='OTHER:ELECTRIC']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:value-of select="substring-after(.,'OTHER:')"/>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 	<!--script implementing change proposal AIXM-158 (for more information please use the following link: https://aixmccb.atlassian.net/browse/AIXM-158 )-->
 <xsl:template match="src_aixm:StandardLevelTable//src_aixm:name[text()='VFR_RVMS']">
-	<xsl:copy>
+	<xsl:element name="aixm:{local-name()}">
 		<xsl:text>VFR_RVSM</xsl:text>
-	</xsl:copy>
+	</xsl:element>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -33,7 +33,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<!--identity transformation to copy the unchanged nodes-->
 <xsl:template match="@* | node()">
 	<xsl:copy>
-		<xsl:apply-templates select="@* | node()" />
+		<xsl:apply-templates select="@* | node()"/>
 	</xsl:copy>
 </xsl:template>
 

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -27,7 +27,11 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	-->
 <!-- Component: XSLT scripts: forward mapping (AIXM 5.1 to AIXM 5.1.1) -->
 
-<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:aixm="http://www.aixm.aero/schema/5.1">
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:aixm="http://www.aixm.aero/schema/5.1">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -21,7 +21,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 		provided by the Open Source Initiative:
 		http://www.opensource.org/licenses/bsd-license.php
 		==========================================
-		Technical note: the scripts have been tested using Saxon Home Edition 9.6.0.5. The transition from Xalan to Saxon was a prerequisite for using a new function implemented with XSLT 2.0 (i.e fn:matches) 
+		Technical note: the scripts have been tested using Saxon Home Edition 9.6.0.5. The transition from Xalan to Saxon was a prerequisite for using a new function implemented with XSLT 2.0 (i.e fn:matches)
 		needed for the implementation of the change proposals. For more details and download links please use the following link: http://saxon.sourceforge.net/ .
 		==========================================
 	-->
@@ -29,7 +29,7 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 
 <xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:fn="http://www.w3.org/2005/xpath-functions" xmlns:aixm="http://www.aixm.aero/schema/5.1">
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
-	
+
 	<!--identity transformation to copy the unchanged nodes-->
 <xsl:template match="@* | node()">
 	<xsl:copy>

--- a/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
+++ b/AIXM_5.1_to_AIXM_5.1.1_Mapping_(forward)_v1.0.xslt
@@ -31,9 +31,9 @@ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY,
 	<xsl:output method="xml" version="1.0" encoding="UTF-8" indent="yes"/>
 
 	<!--identity transformation to copy the unchanged nodes-->
-<xsl:template match="@* | node()">
+<xsl:template match="@*|node()">
 	<xsl:copy>
-		<xsl:apply-templates select="@* | node()"/>
+		<xsl:apply-templates select="@*|node()"/>
 	</xsl:copy>
 </xsl:template>
 


### PR DESCRIPTION
A(n edited) sequence of both frivolous and essential changes:
- Nonsignificant whitespace: pretty well... nonsignificant;
- Correction: actually also nonsignificant (use-when="'[...]'" does nothing because the [effective boolean value](http://www.w3.org/TR/xpath20/#dt-ebv) of a non-empty string is true, but the attribute was both unnecessary and ineffectual because [use-when](https://www.w3.org/TR/xslt20/#conditional-inclusion) has no access to "information contained in the stylesheet itself or in any source document");
- Namespace URIs: should speak for itself;
- Maintainability experiment: fewer lines of code is better?

Disclaimer: these changes and corrections are based on inspection of the stylesheets themselves, and, while a non-trivial document was processed in both directions (from 5.1 to 5.1.1 and back again), with validation of both results and further processing of the 5.1.1 result, no effort was made (yet) to unit-test any data-related transformations (which were possibly not triggered for the processed document).